### PR TITLE
fix: bump to golang 1.21

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -179,7 +179,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
         go_version:
-          - '1.20'
           - '1.21'
     name: Try to install with go ${{ matrix.go_version }}
     steps:


### PR DESCRIPTION
This PR bump to golang 1.21